### PR TITLE
fix: unused imports breaking builds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { ISearchParams, ISearchParamsKeys } from './types/ISearchParams';
 import ZipCode from './models/ZipCode';
 import { zipCodes } from './zip-source-files/us-zip-codes';
-var csv = require('csvtojson');
-import fs from 'fs';
-import ZipCodeMapper from './models/ZipCodeMapper';
+
+// var csv = require('csvtojson');
+// import fs from 'fs';
+// import ZipCodeMapper from './models/ZipCodeMapper';
 
 // function writeCsvToTsArray(
 //   sourceCsv = './zip-source-files/uszips.csv',


### PR DESCRIPTION
There's a bunch of unused imports that are breaking a build in one of my functions that also utilizes `csvtojson`. It doesn't look like that is used for anything in this particular package.